### PR TITLE
update prop type for children

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -37,7 +37,7 @@ ReactToPdf.propTypes = {
   x: PropTypes.number.isRequired,
   y: PropTypes.number.isRequired,
   options: PropTypes.object,
-  children: PropTypes.number.isRequired
+  children: PropTypes.func.isRequired
 };
 
 ReactToPdf.defaultProps = {


### PR DESCRIPTION
The current propTypes raises a console warning when using the supplied example.
Suggest changing from number to func.