### PR TITLE
update jspdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/ivmarcos/react-to-pdf#readme",
   "dependencies": {
     "html2canvas": "^1.0.0-alpha.12",
-    "jspdf": "^1.4.1"
+    "jspdf": "^2.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
First off, big fan of your library, I've been using it for a while now. 

I recently had it scanned for security flaws by a third party (Veracode) and security risks were found in `jspdf` 1.4.1 and some of its sub dependencies e.g `jsdom`. I dug into the docs of `jspdf` comparing it to your current implementation, It doesn't look like any updates are required moving from V1 to V2.  

Let me know if there is anything else needed from me