### PR TITLE
Fixed type definition for the toPDF method

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { MutableRefObject } from "react";
-import { jsPDFOptions } from "jspdf";
+import jsPDF, { jsPDFOptions } from "jspdf";
 import { Options as Html2CanvasOptions } from "html2canvas";
 import { Margin, Resolution } from "./constants";
 
@@ -92,7 +92,7 @@ export type UsePDFResult = {
   /**
    * Generates the pdf
    */
-  toPDF: (options?: Options) => void;
+  toPDF: (options?: Options) => Promise<InstanceType<typeof jsPDF>>;
 };
 
 export type TargetElementFinder =


### PR DESCRIPTION
The toPDF method in reality exports a promise from the jsPDF lib.
The typing was misleading for whom-ever wants to set up a loader or some UI feedback while the process is going.

Fixed the type definition for toPDF method.